### PR TITLE
Feature/issue 24 use reg ex to parse commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ import requests
 from string import Template
 from dotenv import load_dotenv
 import my_strings as ms
+import helpers as h
 
 
 # References praw-ini file
@@ -22,13 +23,71 @@ def run():
     load_dotenv()  # Used for imgur auth
     # TODO: verify that the db path is valid.
     #   A single file is fine but dirs are not created if they don't exist
-    db_setup(DB_FILE)  # TODO: set db file path as CLI parameter
     print("Looking for comments...")
     for comment in r.subreddit(SUBREDDIT_NAME).stream.comments():
         if check_batsignal(comment.body) and not check_has_responded(comment):
-            print(f"Comment hash: {comment}")
-            # TODO: Set respond bool as CLI input value
-            bot_action(comment, respond=RESPOND)
+            response = ms.HELP_TEXT
+            tokens = h.get_and_split_first_line(comment.body)
+            # More than 100 tokens on the first line. 
+            # I'm not dealing with that
+            if len(tokens) > 100:
+                db_obj = h.reply_and_upvote(comment, response=ms.HELP_TEXT, respond=RESPOND)
+                add_comment_to_db(db_obj)
+                continue
+
+            # Check for help
+            if parse_comment(tokens)['help']:
+                db_obj = h.reply_and_upvote(comment, response=ms.HELP_TEXT, respond=RESPOND)
+                add_comment_to_db(db_obj)
+                continue
+
+            index = parse_comment(tokens)['index']
+            # TODO: Wrap/deal with possible exceptions from parsing imgur url
+            comment_imgur_url = parse_comment(tokens)['imgur_url']
+            
+            # Check/parse imgur
+            album_link_map = None
+            album_link = None
+            if comment_imgur_url is not None:
+                album_link_map = parse_imgur_url(comment_imgur_url)
+                album_link = comment_imgur_url
+            elif h.is_imgur_url(comment.submission.url):
+                album_link_map = parse_imgur_url(comment.submission.url)
+                album_link = comment.submission.url
+            else:
+                # No imgur link found. Respond
+                response = 'Sorry, no imgur link found in your comment or the link of the OP.'
+                db_obj = h.reply_and_upvote(comment, response=response, respond=RESPOND)
+                add_comment_to_db(db_obj)
+                continue
+            
+            album_link_type = album_link_map['type']
+            album_link_id   = album_link_map['id']
+            
+            # TODO: Wrap in try/except
+            request_url = build_request_url(album_link_type, album_link_id)
+            
+            r = send_imgur_api_request(request_url)
+            if r is not None and r.status_code == 200:
+                response = None
+                try:
+                    # Parse request and set response text
+                    image_link = get_direct_image_link(r.json(), album_link_type, index)
+                    print(f'Image link: {image_link}')
+                    s = Template(DIRECT_LINK_TEMPLATE)
+                    response = s.substitute(index=index, image_link=image_link, album_link=album_link)
+                except IndexError as e:
+                    response = 'Sorry that index is out of bounds.'
+                db_obj = h.reply_and_upvote(comment, response=response, respond=RESPOND)
+                add_comment_to_db(db_obj)
+                continue 
+            else:  # Status code not 200
+                # TODO: Deal with status codes differently, like if imgur is down or I don't have the env configured
+                print(f'Status Code: {r.status_code}')
+                response = f'Sorry, {album_link} is probably not an existing imgur album, or Imgur is down.'
+                db_obj = h.reply_and_upvote(comment, response=response, respond=RESPOND)
+                add_comment_to_db(db_obj)
+                continue
 
 
 def check_batsignal(comment_body):
@@ -71,9 +130,56 @@ def check_has_responded(comment):
     return val
 
 
+def parse_comment(tokens):
+    pairs = {'index': -1, 'imgur_url': None, 'help': False}
+    # Find the numbers in the tokens
+    for s in tokens:
+        # Look for help
+        if s.lower() == 'help':
+            pairs['help'] = True
+            break
+        # Find the numbers in the tokens
+        if h.isInt(s):
+            pairs['index'] = int(s)
+        # Find imgur URL in the tokens
+        if h.is_imgur_url(s):
+            pairs['imgur_url'] = s
+    return pairs
+
+
+def build_request_url(imgur_link_type, imgur_link_id):
+    """
+    Create the Imgur Request URL.
+    Imgur Galleries and Albums have different endpoints.
+    Any other resource type hasn't been implemented/might not exist.
+    TODO: doctests
+    """
+    if imgur_link_type == 'album':
+        s = Template(IMGUR_ALBUM_API_URL)
+        return s.substitute(album_hash=imgur_link_id)
+    elif imgur_link_type == 'gallery':
+        s = Template(IMGUR_GALLERY_API_URL)
+        return s.substitute(gallery_hash=imgur_link_id)
+    else:
+        raise ValueError('Sorry, that imgur resource hasn\'t been implemented yet.')
+
+
+def send_imgur_api_request(request_url):
+    """
+    Send API request to Imgur
+    TODO: doctests
+    """
+    # Send the request
+    client_id = os.getenv('IMGUR_CLIENT_ID')
+    headers = {'Authorization': f'Client-ID {client_id}'}
+    print(f"Request url: {request_url}")
+    return requests.get(request_url, headers=headers)
+
+
 def bot_action(c, verbose=True, respond=False):
     response_text = 'bot_action text'
     response_type = None
+    # TODO: Get the first line only
     tokens = c.body.split()
     # If there's a command in the comment parse and react
     # Break this out into a "parse_comment_tokens" function
@@ -127,72 +233,23 @@ def bot_action(c, verbose=True, respond=False):
         print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
 
-def get_direct_image_link(comment, tokens):
+
+def get_direct_image_link(r_json, imgur_link_type, index):
     """
-    Gets the direct link to an image from an imgur album based on index.
-    Tokens should look like:
-    ['!MFAImageBot', 'link', '<imgur-link>', '<index>']
-    or
-    ['!MFAImageBot', 'op', '<index>']
+    Parse Imgur API request response JSON for the direct image link.
+    If the index is out of bounds will throw an IndexError.
+
+    TODO: Tests for this are sorely needed. Unsure what happens with all of this refactoring.
+    I _think_ only an IndexError is thrown now.
     """
-    imgur_url = None
-    index = None
-    image_link = ''
-    if len(tokens) >= 4 and tokens[1] == 'link':
-        # Correct num parameters for album provided
-        imgur_url = tokens[2]
-        index = get_index_from_string(tokens[3])
-    elif len(tokens) >= 3 and tokens[1] == 'op':
-        # Correct num parametrs for album in OP
-        # This should generate a 404 or something if the post isn't a link to imgur.
-        imgur_url = comment.submission.url
-        index = get_index_from_string(tokens[2])
+    if imgur_link_type == 'gallery':
+        # Gallery: g_response.data.images[index].link
+        return r_json['data']['images'][index-1]['link']
+    elif imgur_link_type == 'album':
+        # Album: a_response.data[index].link
+        return r_json['data'][index-1]['link']
     else:
-        print('Looks like a malformed `link` or `op` command')
-        raise ValueError(f'Malformed `{tokens[1]}`` command.')
-
-    # This can raise an exception which is fine
-    link_type_and_id = parse_imgur_url(imgur_url)
-    imgur_resource_type = link_type_and_id['type']
-    resource_id = link_type_and_id['id']
-    r = None
-    if link_type_and_id is not None:
-        # Galleries and Albums have different URL endpoints
-        url = ''
-        if imgur_resource_type == 'album':
-            s = Template(IMGUR_ALBUM_API_URL)
-            url = s.substitute(album_hash=resource_id)
-        elif imgur_resource_type == 'gallery':
-            s = Template(IMGUR_GALLERY_API_URL)
-            url = s.substitute(gallery_hash=resource_id)
-        else:
-            raise ValueError('Sorry, that imgur resource hasn\'t been implemented yet.')
-
-        # Send the request
-        client_id = os.getenv('IMGUR_CLIENT_ID')
-        headers = {'Authorization': f'Client-ID {client_id}'}
-        print(f"Request url: {url}")
-        r = requests.get(url, headers=headers)
-
-    # Since I thought 2 lines would make sense here this is probably a good place to separate methods
-    if r is not None and r.status_code == 200:
-        # happy path for now
-        r_json = r.json()
-        image_link = ''
-        if imgur_resource_type == 'gallery':
-            # Gallery: g_response.data.images[index].link
-            image_link = r_json['data']['images'][index-1]['link']
-        elif imgur_resource_type == 'album':
-            # Album: a_response.data[index].link
-            image_link = r_json['data'][index-1]['link']
-        else:
-            raise ValueError('This should be unreachable. Please respond to this comment or open an issue so I see it.')
-        print(f'Image link: {image_link}')
-        return {'image_link': image_link, 'index': index, 'album_link': imgur_url}
-    else:  # Status code not 200
-        # TODO: Deal with status codes differently, like if imgur is down or I don't have the env configured
-        print(f'Status Code: {r.status_code}')
-        raise ValueError(f'Sorry, {imgur_url} is probably not an existing imgur album.')
+        raise ValueError('This should be unreachable. Please respond to this comment or open an issue so I see it.')   
 
 
 def get_index_from_string(str):
@@ -260,11 +317,45 @@ def parse_imgur_url(url):
     }
 
 
+def is_number_list(string):
+    """
+    Trying to build a method to check for lists for numbers
+
+    >>> is_number_list('1,2,3')
+    True
+    >>> parse_imgur_url('HtTP://imgur.COM:80/gallery/59npG')
+    {'id': '59npG', 'type': 'gallery'}
+    >>> parse_imgur_url('https://i.imgur.com/altd8Ld.png')
+    {'id': 'altd8Ld', 'type': 'image'}
+    >>> parse_imgur_url('https://i.stack.imgur.com/ELmEk.png')
+    {'id': 'ELmEk', 'type': 'image'}
+    >>> parse_imgur_url('http://not-imgur.com/altd8Ld.png') is None
+    Traceback (most recent call last):
+      ...
+    ValueError: Sorry, "http://not-imgur.com/altd8Ld.png" is not a valid imgur URL
+    >>> parse_imgur_url('tftp://imgur.com/gallery/59npG') is None
+    Traceback (most recent call last):
+      ...
+    ValueError: Sorry, "tftp://imgur.com/gallery/59npG" is not a valid imgur URL
+    >>> parse_imgur_url('Blah') is None
+    Traceback (most recent call last):
+      ...
+    ValueError: Sorry, "Blah" is not a valid imgur URL
+    """
+    match = re.match(r'^[1-9]+(,[1-9]+)*$', string)
+
 def add_comment_to_db(db_dict):
+    """
+    Adds the comment and its info to the database
+    """
+    # print(f"Hash: {db_dict['hash']}")
+    print(f"Has responded: {db_dict['has_responded']}")
+    print(f"Response text: ")
+    print(f"{db_dict['response_text']}")
     conn = sqlite3.connect(DB_FILE)
     cur = conn.cursor()
     # https://stackoverflow.com/questions/19337029/insert-if-not-exists-statement-in-sqlite
-    cur.execute('INSERT OR REPLACE INTO comments VALUES (:hash, :has_responded, :response_type)', db_dict)
+    cur.execute('INSERT OR REPLACE INTO comments VALUES (:hash, :has_responded, :response_text)', db_dict)
     conn.commit()
     conn.close()
 
@@ -276,7 +367,7 @@ def db_setup(db_file):
     cur.execute('''CREATE TABLE IF NOT EXISTS comments (
         comment_hash  TEXT       NOT NULL  UNIQUE,
         has_responded INTEGER    DEFAULT 0,
-        response_type TEXT       DEFAULT NULL,
+        response_text TEXT       DEFAULT NULL,
         CHECK(has_responded = 0 OR has_responded = 1)
     )''')
     conn.commit()
@@ -311,4 +402,6 @@ if __name__ == '__main__':
     print(f"DB file: {DB_FILE}")
     print(f"Subreddit name: {SUBREDDIT_NAME}")
     print(f"Respond: {RESPOND}")
+    print("~~~~~~~~~~")
+    db_setup(DB_FILE)  # TODO: set db file path as CLI parameter
     run()

--- a/helpers.py
+++ b/helpers.py
@@ -54,3 +54,34 @@ def reply_and_upvote(c, response, respond=False):
     # TODO: Make "responded" more dependent on whether we were actually able to respond to the comment.
     #   and not just what the bot is being told to do.
     return {'hash': c.id, 'has_responded': respond, 'response_text': response}
+
+
+### Unused
+def get_index_from_string(str):
+    """
+    Wrap this in a try-except because I don't like the error message
+
+    >>> get_index_from_string('1')
+    1
+    >>> get_index_from_string('1.1')
+    Traceback (most recent call last):
+      ...
+    ValueError: Sorry, "1.1" doesn't look like an integer to me.
+    >>> get_index_from_string('notAnInt')
+    Traceback (most recent call last):
+      ...
+    ValueError: Sorry, "notAnInt" doesn't look like an integer to me.
+    """
+    index = None
+    try:
+        index = int(str)
+    except ValueError:
+        raise ValueError(f'Sorry, "{str}" doesn\'t look like an integer to me.')
+    return index
+
+
+def is_number_list(string):
+    """
+    Trying to build a method to check for lists for numbers
+    """
+    match = re.match(r'^[1-9]+(,[1-9]+)*$', string)

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,56 @@
+import re
+import my_strings
+
+def isInt(s):
+    """
+    Helper function to see if a string is an int.
+    TODO: Add doctests
+    """
+    try: 
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+
+def is_imgur_url(s):
+    """
+    Returns truthy value if s is an imgur URL. None otherwise. But this should work with an if.
+
+    Just ripped the regex from the parse method. The group names aren't needed really.
+    TODO: Add doctests
+    """
+    return re.match(
+        r'^(?i:https?://(?:[^/:]+\.)?imgur\.com)(:\d+)?'
+        r'/(?:(?P<album>a/)|(?P<gallery>gallery/))?(?P<id>\w+)',
+        s
+    )
+
+def get_and_split_first_line(string):
+    """
+    Given a string return a list of the tokens in the first line.
+
+    TODO: doctests
+    """
+    return string.splitlines()[0].split()
+
+def reply_and_upvote(c, response, respond=False):
+    """
+    Respond to and upvote comment.
+
+    Returns DB Object. This is a bad idea
+    """
+    print('-------------------------------------------------')
+    if respond:
+        print(f'Responding to comment{c.permalink}')
+        c.reply(response + my_strings.TAIL)
+        c.upvote()
+    else:
+        print(f'Not responding to comment {c.permalink}')
+    
+    print('Comment text: ')
+    print(f'{c.body}')
+    # Adding everything to the DB
+    # TODO: Make "responded" more dependent on whether we were actually able to respond to the comment.
+    #   and not just what the bot is being told to do.
+    return {'hash': c.id, 'has_responded': respond, 'response_text': response}

--- a/misc/post.md
+++ b/misc/post.md
@@ -1,8 +1,10 @@
+Link: https://imgur.com/a/jWvLA
+
 Hello, this is MFAImageBot! A bot built to help directly link images from large inspiration albums. 
 
-Ever been scrolling through an [awesome album]() and you just *had* to know where the sweet killshots in image 42 came from? So you make a comment asking for help, but since you're on your phone you just ask "What are those dope kicks in #42?" and don't link the photo. No harm no foul.
+Ever been scrolling through an [awesome album](https://imgur.com/a/jWvLA) and you just *had* to know where the sweet killshots in image 42 came from? So you make a comment asking for help, but since you're on your phone you just ask "What are those dope kicks in #42?" and don't link the photo. No harm no foul.
 
-Now anyone who wants to help you out will have to go back to the album and count all the way to image 42 just to see if they even know or not! This bot is intended to solve that problem and make this a lot easier. 
+However, anyone who wants to help you out will have to go back to the album and count all the way to image 42 just to see if they even know or not! This bot is intended to solve that problem and make this a lot easier. 
 
 ## Usage  
 The bot listens for comments which begin with `!MFAImageBot` and then attempts to fullfil the request in the comment.
@@ -19,15 +21,22 @@ Here's the help message:
 
 The bot will (should) ignore everything after the correct commands and inputs. So you can make a comment with text after the commands and numbers without issue, [like this one.](https://www.reddit.com/r/malefashionadvice/comments/goj5w8/converse_mfa_footwear_basics_6/frgmcys/?context=1) 
 
-Also, *anyone* can call this bot *anywhere* within /r/malefashionadvice. So if someone asks about a particular image, but doesn't link it, feel free to call the bot. It should respond in less than ~30s if Imgur's API and Reddit are working properly. 
+Also, *anyone* can call this bot *anywhere* within /r/malefashionadvice. So if someone asks about a particular image, but doesn't link it, feel free to call the bot. It should respond in less than ~1m if Imgur's API and Reddit are working properly. 
 
 ## Code  
-I've open-sourced the code for this bot [here](https://github.com/AlexBurkey/MFAImageBot) if you'd like to contribute ideas or anything. I'm working on this mostly as a personal project for my own benefit and learning but feel free to clone, fork, submit PRs, etc. 
+I've open-sourced the code for this bot [here](https://github.com/AlexBurkey/MFAImageBot) if you'd like to contribute ideas or anything. I'm working on this mostly as a personal project for my own knowledge/learning benefit but feel free to clone, fork, submit PRs, etc. 
+
+If you find a bug please open an issue [here](https://github.com/AlexBurkey/MFAImageBot/issues/new?assignees=AlexBurkey&labels=bug&template=bug_report.md&title=) or just PM/message the bot.
+
+If you have an idea for a feature/enhancement you can suggest it [here.](https://github.com/AlexBurkey/MFAImageBot/issues/new?assignees=AlexBurkey&labels=enhancement&template=feature_request.md&title=)
 
 ## Restrictions/FYIs  
 * The bot only works with Imgur albums/galleries. Imgur is by-far the most common image host for these things, but it will definitely not work for other endpoints right now.
+* Imgur albums and the API can be kind of weird if the images in the album have been rearranged. I'm not sure if this is just a propagation issue on Imgur's side or if it permenantly breaks an album's numbering from the API's standpoint.
 * The `op` command (currently) only works if the reddit submission is a link-post to an Imgur album/gallery. It doesn't look through the text of self-posts.
-* The bot is currently setup to only monitor comments in /r/malefashionadvice and won't work if you call it in a post body or in any other subreddit.
-* I expect this bot to break occasionally as I'm building up testing and such. If you run into a weird issue you can PM the bot or [open an issue.](https://github.com/AlexBurkey/MFAImageBot/issues/new/choose) Think of this as a beta.
+* The bot is currently setup to only monitor comments in /r/malefashionadvice and won't work if you call it in a post body or in another subreddit.
+* I expect this bot to break occasionally as I'm building up testing and such. If you run into a weird issue you can PM the bot or [open an issue.](https://github.com/AlexBurkey/MFAImageBot/issues/new?assignees=AlexBurkey&labels=bug&template=bug_report.md&title=) Think of this as a beta.
 
-I'll be around to answer any questions. I also made this post an image post so feel free to test it out!
+I'll be around for a bit to answer any questions. I also made this post an image post so feel free to test it out!
+
+Credit for the album goes to the famous /u/jdbee from [this post](https://www.reddit.com/r/malefashionadvice/comments/17zyk1/100_outfit_compilations_a_collection_of/)

--- a/my_strings.py
+++ b/my_strings.py
@@ -7,10 +7,11 @@ SUBREDDIT_NAME = "malefashionadvice"
 TODO_TEXT = "Sorry, this function has not been implemented yet.\n\n"
 HELP_TEXT = ("Usage: I respond to comments starting with `!MFAImageBot`.  \n"
              "`!MFAImageBot help`: Print this help message.  \n"
-             "`!MFAImageBot link <album-link> <number>`: Attempts to directly link the <number> image from <album-link>  \n"
-             "`!MFAImageBot op <number>`: Attempts to directly link the <number> image from the album in the submission  \n"
+             "`!MFAImageBot <album-link> <number>`: Attempts to directly link the <number> image from <album-link>  \n"
+             "`!MFAImageBot <number>`: Attempts to directly link the <number> image from the album in the submission  \n"
              )
 TAIL = ("\n\n---\nI am a bot! If you've found a bug you can open an issue "
         "[here.](https://github.com/AlexBurkey/MFAImageBot/issues/new?template=bug_report.md)  \n"
         "If you have an idea for a feature, you can submit the idea "
-        "[here](https://github.com/AlexBurkey/MFAImageBot/issues/new?template=feature_request.md)")
+        "[here](https://github.com/AlexBurkey/MFAImageBot/issues/new?template=feature_request.md)  \n"
+        "Version 1.1")

--- a/my_strings.py
+++ b/my_strings.py
@@ -1,0 +1,16 @@
+USER_AGENT = 'MFAImageBot'
+
+DB_FILE = 'mfa.db'
+SUBREDDIT_NAME = "malefashionadvice"
+
+
+TODO_TEXT = "Sorry, this function has not been implemented yet.\n\n"
+HELP_TEXT = ("Usage: I respond to comments starting with `!MFAImageBot`.  \n"
+             "`!MFAImageBot help`: Print this help message.  \n"
+             "`!MFAImageBot link <album-link> <number>`: Attempts to directly link the <number> image from <album-link>  \n"
+             "`!MFAImageBot op <number>`: Attempts to directly link the <number> image from the album in the submission  \n"
+             )
+TAIL = ("\n\n---\nI am a bot! If you've found a bug you can open an issue "
+        "[here.](https://github.com/AlexBurkey/MFAImageBot/issues/new?template=bug_report.md)  \n"
+        "If you have an idea for a feature, you can submit the idea "
+        "[here](https://github.com/AlexBurkey/MFAImageBot/issues/new?template=feature_request.md)")

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ FAILS=0
 
 while true
 do
-  python3 -u bot.py # your program
+  python3 -u bot.py prod # your program
   EXIT=$?
   ((FAILS++))
 

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ while true
 do
   # your program
   # Sends output to ./logs/bot file
-  python3 -u bot.py >> "./logs/bot/$(date +"%FT%H%M%S").out" 
+  python3 -u bot.py prod >> "./logs/bot/$(date +"%FT%H%M%S").out" 
   EXIT=$?
   ((FAILS++))
 


### PR DESCRIPTION
Bot now uses regex to parse the first line of a calling comment. This removes the need for commands `op` and `link` and closes #15 . Also some major refactoring.

Closes #15 
Closes #24 